### PR TITLE
Make Kafka home dir if necessary in pre.

### DIFF
--- a/kafka.spec
+++ b/kafka.spec
@@ -53,6 +53,7 @@ rm -rf $RPM_BUILD_ROOT
 %pre
 /usr/bin/getent group kafka >/dev/null || /usr/sbin/groupadd -r kafka
 if ! /usr/bin/getent passwd kafka >/dev/null ; then
+    %{__mkdir_p} %{_prefix}/kafka
     /usr/sbin/useradd -r -g kafka -m -d %{_prefix}/kafka -s /bin/bash -c "Kafka" kafka
 fi
 


### PR DESCRIPTION
Looking online for the problem I found a suggestion that useradd can only create the last directory in a path, so using `mkdir -p` first should fix the issue.